### PR TITLE
Remove BUILDPACK_URL

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,7 +8,6 @@
       "heroku-redis:test"
   ],
   "env": {
-      "BUILDPACK_URL": "https://github.com/heroku/heroku-buildpack-go",
       "SATELLITE_REDIS_URL_KEY": "REDIS_URL"
   }
 }


### PR DESCRIPTION
This is no longer required as we now officially support Go: https://blog.heroku.com/archives/2015/7/7/go_support_now_official_on_heroku
